### PR TITLE
fixes warning: does not have an extra named `dev`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ line-length = 120
 target-version = "py39"
 lint.select = ["I"]# implementation for isort
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "mkdocs-material>=9.5.49",
     "mkdocs>=1.6.1",


### PR DESCRIPTION
#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

- without this, gives warning:
```
 + requests==2.32.4
 + russian-roulette-trader==0.0.1 (from file:///Users/Deependu/quant/RussianRouletteTrader)
 + urllib3==2.5.0
warning: The package `russian-roulette-trader @ file:///Users/Deependu/quant/RussianRouletteTrader` does not have an extra named `dev`
--------------------------------
Environment setup complete!
```

- after this fix
```
 + ruff==0.12.4
 ~ russian-roulette-trader==0.0.1 (from file:///Users/Deependu/quant/RussianRouletteTrader)
 + uv==0.8.0
--------------------------------
Environment setup complete!
```


#### Type of change
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Did you update CHANGELOG in case of a major change?
